### PR TITLE
string int

### DIFF
--- a/src/common/db.c
+++ b/src/common/db.c
@@ -136,7 +136,7 @@ int db_doWithOBJ(void (*func1)(const char*, int), void (*func2)(const char *))
     result = mysql_use_result(conn);
     while(row= mysql_fetch_row(result))
     {
-        func1(row[0], row[1]);
+        func1(row[0], atoi(row[1]));
         func2(row[0]);
     }
     mysql_free_result(result);

--- a/src/tk115/msg_proc_app.c
+++ b/src/tk115/msg_proc_app.c
@@ -267,5 +267,6 @@ void app_log_callback(struct mosquitto *mosq __attribute__((unused)), void *user
 
 void app_publish_callback(struct mosquitto *mosq __attribute__((unused)), void *userdata __attribute__((unused)), int mid __attribute__((unused)))
 {
-
+	LOG_DEBUG("Published mid: %d", mid);
+	LOG_INFO("Publish mid: %d successfully", mid);
 }


### PR DESCRIPTION
之前从DB里读取int时没有转型，导致读取数据出现错误，如果时间戳没有更新，则再次存入时时间有误