### PR TITLE
修改服务器崩溃的bug

### DIFF
--- a/src/simcom/server_simcom.c
+++ b/src/simcom/server_simcom.c
@@ -60,9 +60,11 @@ static void event_cb(struct bufferevent *bev, short events, void *arg)
 		LOG_INFO("simcom connection timeout!");
 
 		session_del((SESSION *) arg);
-		bufferevent_free(bev);
+		//bufferevent_free(bev);
 		evutil_socket_t socket = bufferevent_getfd(bev);
 		EVUTIL_CLOSESOCKET(socket);
+        
+        bufferevent_free(bev);
 	}
 	else if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR))
 	{


### PR DESCRIPTION
崩溃的原因是buffereventfree函数调用过早，在bev被释放后还使用了其值。